### PR TITLE
Speed optimizations

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -49,7 +49,7 @@ library
   build-depends:    base       == 4.*,
                     containers >= 0.5 && < 0.6,
                     binary     >= 0.7 && < 0.9,
-                    bytestring >= 0.9.0,
+                    bytestring >= 0.10.4,
                     array      >= 0.2 && < 0.6
   exposed-modules:  GHC.RTS.Events,
                     GHC.RTS.EventsIncremental

--- a/src/GHC/RTS/EventsIncremental.hs
+++ b/src/GHC/RTS/EventsIncremental.hs
@@ -7,6 +7,7 @@ This module contains functions used for parsing *.eventlog files emitted
 by the GHC runtime sytem.
 -}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-
 -}
 
@@ -39,11 +40,13 @@ import GHC.RTS.EventTypes hiding (time, spec)
 import Data.Binary.Get hiding (remaining)
 import Data.Binary.Put
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
 import Control.Concurrent (threadDelay)
 import qualified Data.IntMap.Strict as M
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import System.IO (Handle, hPutStrLn, stderr)
+import System.IO (Handle, hPutStrLn, stderr, stdout)
+import Data.Monoid ((<>))
 import Data.Word (Word16, Word32)
 
 
@@ -364,7 +367,7 @@ printEventsIncremental eh dashf = do
     event <- ehReadEvent eh
     case event of
       Item ev -> do
-          putStrLn (ppEvent' ev) -- if actual printing is needed
+          BB.hPutBuilder stdout (buildEvent ev <> "\n") -- if actual printing is needed
           printEventsIncremental eh dashf
       Incomplete ->
         if dashf


### PR DESCRIPTION
This PR does two speed optimizations:

* Use bytestring builder rather than String to pretty print events
* Avoid repetitive reconstruction of event decoder

The improvement is rather drastic:

```
% ls -lh ghc-events.eventlog
-rw-r--r--  1 maoe  staff    54M Feb 10 18:30 ghc-events.eventlog
% cat ghc-events.eventlog > /dev/null
% ./ghc-events.master inc ghc-events.eventlog > master.out +RTS -sstderr
 207,094,188,704 bytes allocated in the heap
   1,387,436,192 bytes copied during GC
          92,904 bytes maximum residency (2 sample(s))
          44,920 bytes maximum slop
               2 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     397464 colls,     0 par    9.747s   9.987s     0.0000s    0.0012s
  Gen  1         2 colls,     0 par    0.001s   0.001s     0.0004s    0.0007s

  INIT    time    0.000s  (  0.002s elapsed)
  MUT     time   73.893s  ( 75.288s elapsed)
  GC      time    9.748s  (  9.988s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   83.642s  ( 85.278s elapsed)

  %GC     time      11.7%  (11.7% elapsed)

  Alloc rate    2,802,625,175 bytes per MUT second

  Productivity  88.3% of total user, 88.3% of total elapsed
% ./ghc-events.speed-opt inc ghc-events.eventlog > speed-opt.out +RTS -sstderr
  13,985,347,472 bytes allocated in the heap
      11,922,160 bytes copied during GC
          85,936 bytes maximum residency (2 sample(s))
          43,616 bytes maximum slop
               2 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     25140 colls,     0 par    0.502s   0.514s     0.0000s    0.0007s
  Gen  1         2 colls,     0 par    0.001s   0.001s     0.0004s    0.0007s

  INIT    time    0.000s  (  0.002s elapsed)
  MUT     time    4.009s  (  4.384s elapsed)
  GC      time    0.502s  (  0.515s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time    4.513s  (  4.901s elapsed)

  %GC     time      11.1%  (10.5% elapsed)

  Alloc rate    3,488,077,971 bytes per MUT second

  Productivity  88.9% of total user, 89.5% of total elapsed
% diff -w master.out speed-opt.out; echo $?
0
```

The behavior is almost the same except for the leading space in timestamps. `master` uses `printf "%9d"` but this branch replaced it with `BB.word64Dec` so no leading space. Please let me know if this is a problem.

Also this branch is based off of the travis branch. I can rebase onto master if that's better.