### PR TITLE
Use the default GHC RTS in the ghc-events executable

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -67,7 +67,6 @@ executable ghc-events
   main-is:          GhcEvents.hs
   build-depends:    base, containers, binary, bytestring, array
   extensions:	    RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
-  ghc-options:      -debug
 
 test-suite test-versions
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
This is mainly for my convenience. I don't have `debug_p` version of RTS so profiling build always fails with
```
ld: library not found for -lHSrts_debug_p
clang: error: linker command failed with exit code 1 (use -v to see invocation)
`clang' failed in phase `Linker'. (Exit code: 1)
```

If there a good reason to use `-debug` for the `ghc-events` executable? If not, let's drop it.