### PR TITLE
Relax upper version bound for binary

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -48,7 +48,7 @@ source-repository head
 library
   build-depends:    base       == 4.*,
                     containers >= 0.5 && < 0.6,
-                    binary     >= 0.7 && < 0.9,
+                    binary     >= 0.7 && < 0.10,
                     bytestring >= 0.10.4,
                     array      >= 0.2 && < 0.6
   exposed-modules:  GHC.RTS.Events,


### PR DESCRIPTION
There seem to be no breaking changes in binary-0.9.

https://github.com/kolmodin/binary/blob/master/changelog.md#binary-0900