### PR TITLE
Fix overflowed literals warning

### DIFF
--- a/src/GHC/RTS/EventTypes.hs
+++ b/src/GHC/RTS/EventTypes.hs
@@ -524,5 +524,5 @@ fromMsgTag = (+ offset) . fromIntegral . fromEnum
 -- has no associated capability
 mkCap :: Int -> Maybe Int
 mkCap cap = do
-  guard $ fromIntegral cap /= (-1 :: Word16)
+  guard $ fromIntegral cap /= (maxBound :: Word16)
   return cap


### PR DESCRIPTION
If I compile with ghc-8.0.2-rc1 I get

```
src/GHC/RTS/EventTypes.hs:527:33: warning: [-Woverflowed-literals]
    Literal -1 is out of the Word16 range 0..65535
    |
527 |   guard $ fromIntegral cap /= (-1 :: Word16)
    | 
```

This is a fix for the issue.