### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ install:
  - rm -fv cabal.project.local
  - "echo 'packages: .' > cabal.project"
  - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2
+ - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
+ - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -80,19 +80,12 @@ script:
  - "echo 'packages: .' > cabal.project"
  # this builds all libraries and executables (without tests/benchmarks)
  - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks
+ - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
  # this builds all libraries and executables (including tests/benchmarks)
  # - rm -rf ./dist-newstyle
- - cabal new-build -w ${HC} ${TEST} ${BENCH}
 
- # there's no 'cabal new-test' yet, so let's emulate for now
- - TESTS=( $(awk 'tolower($0) ~ /^test-suite / { print $2 }' *.cabal) )
- - if [ "$TEST" != "--enable-tests" ]; then TESTS=(); fi
- - shopt -s globstar;
-   RC=true; for T in ${TESTS[@]}; do echo "== $T ==";
-   if [ -x dist-newstyle/build/**/$SRC_BASENAME/**/build/$T/$T ]; then
-     if dist-newstyle/build/**/$SRC_BASENAME/**/build/$T/$T; then echo "= $T OK ="; else echo "= $T FAILED ="; RC=false; fi;
-   fi;
-   done; $RC
+ # build & run tests
+ - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+ - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
 
 # EOF


### PR DESCRIPTION
I recreated .travis.yml from the latest multi-ghc-travis. This eliminates the need of hacky emulation of `cabal new-test`.