### PR TITLE
Record skipped event data in events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.9.0 - unreleased
+
+* Event parser (`getEvent`) now reads extra unparsed data after events (instead of skipping them as before) and put it in the new `evExtras` field. This field is used to implement round-trip property of `getEvent`/`putEvent`. See [#42](https://github.com/haskell/ghc-events/issues/42) for more details.
+    * This is a breaking change (a new field `evExtras` added to `Event`)
+
 ## 0.8.0 - 2018-07-11
 
 * Add HeapProfBreakdownClosureType ([#33](https://github.com/haskell/ghc-events/pull/33), [#39](https://github.com/haskell/ghc-events/pull/39))

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -1,5 +1,5 @@
 name:             ghc-events
-version:          0.8.0
+version:          0.9.0
 synopsis:         Library and tool for parsing .eventlog files from GHC
 description:      Parses .eventlog files emitted by GHC 6.12.1 and later.
                   Includes the ghc-events tool permitting, in particular,

--- a/src/GHC/RTS/EventTypes.hs
+++ b/src/GHC/RTS/EventTypes.hs
@@ -6,6 +6,7 @@ import Data.Bits
 import Data.Binary
 import Data.Text (Text)
 import qualified Data.Vector.Unboxed as VU
+import Data.ByteString (ByteString)
 
 -- EventType.
 type EventTypeNum = Word16
@@ -126,9 +127,10 @@ data EventType =
 
 data Event =
   Event {
-    evTime  :: {-# UNPACK #-}!Timestamp,
-    evSpec  :: EventInfo,
-    evCap :: Maybe Int
+    evTime   :: {-# UNPACK #-}!Timestamp,
+    evSpec   :: EventInfo,
+    evCap    :: Maybe Int,
+    evExtras :: !ByteString
   } deriving Show
 
 {-# DEPRECATED time "The field is now called evTime" #-}

--- a/src/GHC/RTS/Events.hs
+++ b/src/GHC/RTS/Events.hs
@@ -171,7 +171,7 @@ capSplitEvents' evts imap =
 -- its capability. All events are expected to belong to the same cap.
 addBlockMarker :: Int -> [Event] -> [Event]
 addBlockMarker cap evts =
-  (Event startTime (EventBlock endTime cap sz) (mkCap cap)) : sortedEvts
+  (Event startTime (EventBlock endTime cap sz) (mkCap cap) mempty) : sortedEvts
   where
     sz = fromIntegral . BL.length $ P.runPut $ mapM_ putEvent evts
     startTime = case sortedEvts of

--- a/src/GHC/RTS/Events.hs
+++ b/src/GHC/RTS/Events.hs
@@ -171,7 +171,7 @@ capSplitEvents' evts imap =
 -- its capability. All events are expected to belong to the same cap.
 addBlockMarker :: Int -> [Event] -> [Event]
 addBlockMarker cap evts =
-  (Event startTime (EventBlock endTime cap sz) (mkCap cap) mempty) : sortedEvts
+  (Event startTime (EventBlock endTime cap sz) (mkCap cap) B.empty) : sortedEvts
   where
     sz = fromIntegral . BL.length $ P.runPut $ mapM_ putEvent evts
     startTime = case sortedEvts of

--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -101,7 +101,7 @@ getEvent (EventParsers parsers) = do
   if etRef == EVENT_DATA_END
      then return Nothing
      else do !evTime   <- get
-             evSpec <- parsers ! fromIntegral etRef
+             (evSpec, evExtras) <- parsers ! fromIntegral etRef
              return $ Just Event { evCap = undefined, .. }
 
 --
@@ -957,6 +957,7 @@ putEvent Event {..} = do
     putType (eventTypeNum evSpec)
     put evTime
     putEventSpec evSpec
+    putByteString evExtras
 
 putEventSpec :: EventInfo -> PutM ()
 putEventSpec (Startup caps) = do

--- a/src/GHC/RTS/Events/Merge.hs
+++ b/src/GHC/RTS/Events/Merge.hs
@@ -83,8 +83,8 @@ sh :: Num a => a -> a -> a
 sh x y = x + y
 
 updateSpec :: (EventInfo -> EventInfo) -> Event -> Event
-updateSpec f (Event {evTime = t, evSpec = s, evCap = cap}) =
-    Event {evTime = t, evSpec = f s, evCap = cap}
+updateSpec f (Event {evTime = t, evSpec = s, evCap = cap, evExtras = e}) =
+    Event {evTime = t, evSpec = f s, evCap = cap, evExtras = e}
 
 shift :: MaxVars -> [Event] -> [Event]
 shift (MaxVars mcs mc mt) = map (updateSpec shift')


### PR DESCRIPTION
With this patch we record any skipped data of an event in `Event`, to be able
to serialize `Event`s with skipped data as they were generated by GHC. This in
turn gives us roundtrip property for more events (but not for all events, for
that we need to fix #14).

Fixes #41