### PR TITLE
Tighten lower bound for base to exclude GHC < 7.8

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -64,7 +64,7 @@ source-repository head
   location: git@github.com:haskell/ghc-events.git
 
 library
-  build-depends:    base       >= 4 && < 4.13,
+  build-depends:    base       >= 4.7 && < 4.13,
                     containers >= 0.5 && < 0.7,
                     binary     >= 0.7 && < 0.11,
                     bytestring >= 0.10.4,


### PR DESCRIPTION
Fixes #44.