### PR TITLE
Fixes for newer cabal/ghc versions.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+
+packages: ./ghc-events.cabal

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -1,5 +1,5 @@
 name:             ghc-events
-version:          0.9.0
+version:          0.9.1
 synopsis:         Library and tool for parsing .eventlog files from GHC
 description:      Parses .eventlog files emitted by GHC 6.12.1 and later.
                   Includes the ghc-events tool permitting, in particular,

--- a/src/GHC/RTS/Events/Incremental.hs
+++ b/src/GHC/RTS/Events/Incremental.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiWayIf #-}
+
 module GHC.RTS.Events.Incremental
   ( -- * Incremental API
     Decoder(..)
@@ -110,12 +111,12 @@ readHeader = go $ Left decodeHeader
       Left decoder -> case decoder of
         Produce header decoder' -> case decoder' of
           Done leftover -> Right (header, BL.Chunk leftover bytes)
-          _ -> fail "readHeader: unexpected decoder"
+          _ -> Left "readHeader: unexpected decoder"
         Consume k -> case bytes of
-          BL.Empty -> fail "readHeader: not enough bytes"
+          BL.Empty -> Left "readHeader: not enough bytes"
           BL.Chunk chunk chunks -> go (Left $! k chunk) chunks
-        Done _ -> fail "readHeader: unexpected termination"
-        Error _ err -> fail err
+        Done _ -> Left "readHeader: unexpected termination"
+        Error _ err -> Left err
       Right header -> Right (header, bytes)
 
 


### PR DESCRIPTION
Use `Left` explicitly instead of `fail`
to avoid breakage with Monad fail.

Add cabal.project file.

Bump version to 0.9.1