### PR TITLE
Fix string encodings.

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -101,14 +101,14 @@ library
                     GHC.RTS.Events.Binary
   hs-source-dirs:   src
   include-dirs:     include
-  extensions:	    RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   other-extensions: FlexibleContexts, CPP
   ghc-options:      -Wall
 
 executable ghc-events
   main-is:          GhcEvents.hs
   build-depends:    ghc-events, base, containers
-  extensions:	    RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
 
 test-suite test-versions
   type:             exitcode-stdio-1.0
@@ -116,7 +116,7 @@ test-suite test-versions
   other-modules:    Utils
   hs-source-dirs:   ., test
   build-depends:    ghc-events, base
-  extensions:	    RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
 
 test-suite write-merge
   type:             exitcode-stdio-1.0
@@ -124,5 +124,5 @@ test-suite write-merge
   other-modules:    Utils
   hs-source-dirs:   ., test
   build-depends:    ghc-events, base, bytestring
-  extensions:	    RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   buildable:        False

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -126,3 +126,11 @@ test-suite write-merge
   build-depends:    ghc-events, base, bytestring
   extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
   buildable:        False
+
+test-suite roundtrip
+  type:             exitcode-stdio-1.0
+  main-is:          Roundtrip.hs
+  other-modules:    Utils
+  hs-source-dirs:   ., test
+  build-depends:    ghc-events, base
+  extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -125,6 +125,7 @@ test-suite write-merge
   hs-source-dirs:   ., test
   build-depends:    ghc-events, base, bytestring
   extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  -- disabled until #14 is fixed
   buildable:        False
 
 test-suite roundtrip
@@ -134,3 +135,5 @@ test-suite roundtrip
   hs-source-dirs:   ., test
   build-depends:    ghc-events, base
   extensions:	      RecordWildCards, NamedFieldPuns, BangPatterns, PatternGuards
+  -- disabled until #14 is fixed
+  buildable:        False

--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 module GHC.RTS.Events.Binary
   ( -- * Readers
     getHeader
@@ -912,13 +913,12 @@ putHeader (Header ets) = do
     putMarker EVENT_HET_END
     putMarker EVENT_HEADER_END
  where
-    putEventType (EventType n d msz) = do
+    putEventType (EventType n (TE.encodeUtf8 -> d) msz) = do
         putMarker EVENT_ET_BEGIN
         putType n
         putE $ fromMaybe 0xffff msz
-        let d' = TE.encodeUtf8 d
-        putE (fromIntegral $ B.length d' :: EventTypeDescLen)
-        putByteString d'
+        putE (fromIntegral $ B.length d :: EventTypeDescLen)
+        putByteString d
         -- the event type header allows for extra data, which we don't use:
         putE (0 :: Word32)
         putMarker EVENT_ET_END
@@ -1136,11 +1136,10 @@ putEventSpec (WakeupThread t c) = do
     putE t
     putCap c
 
-putEventSpec (ThreadLabel t l) = do
-    let l' = TE.encodeUtf8 l
-    putE (fromIntegral (B.length l') + sz_tid :: Word16)
+putEventSpec (ThreadLabel t (TE.encodeUtf8 -> l)) = do
+    putE (fromIntegral (B.length l) + sz_tid :: Word16)
     putE t
-    putByteString l'
+    putByteString l
 
 putEventSpec Shutdown =
     return ()
@@ -1246,25 +1245,22 @@ putEventSpec (CapsetRemoveCap cs cp) = do
     putE cs
     putCap cp
 
-putEventSpec (RtsIdentifier cs rts) = do
-    let rts' = TE.encodeUtf8 rts
-    putE (fromIntegral (B.length rts') + sz_capset :: Word16)
+putEventSpec (RtsIdentifier cs (TE.encodeUtf8 -> rts)) = do
+    putE (fromIntegral (B.length rts) + sz_capset :: Word16)
     putE cs
-    putByteString rts'
+    putByteString rts
 
-putEventSpec (ProgramArgs cs as) = do
-    let as' = map TE.encodeUtf8 as
-    let sz_args = sum (map ((+ 1) {- for \0 -} . B.length) as') - 1
+putEventSpec (ProgramArgs cs (map TE.encodeUtf8 -> as)) = do
+    let sz_args = sum (map ((+ 1) {- for \0 -} . B.length) as) - 1
     putE (fromIntegral sz_args + sz_capset :: Word16)
     putE cs
-    mapM_ putByteString (intersperse "\0" as')
+    mapM_ putByteString (intersperse "\0" as)
 
-putEventSpec (ProgramEnv cs es) = do
-    let es' = map TE.encodeUtf8 es
-    let sz_env = sum (map ((+ 1) {- for \0 -} . B.length) es') - 1
+putEventSpec (ProgramEnv cs (map TE.encodeUtf8 -> es)) = do
+    let sz_env = sum (map ((+ 1) {- for \0 -} . B.length) es) - 1
     putE (fromIntegral sz_env + sz_capset :: Word16)
     putE cs
-    mapM_ putByteString $ intersperse "\0" es'
+    mapM_ putByteString $ intersperse "\0" es
 
 putEventSpec (OsProcessPid cs pid) = do
     putE cs
@@ -1279,20 +1275,17 @@ putEventSpec (WallClockTime cs sec nsec) = do
     putE sec
     putE nsec
 
-putEventSpec (Message s) = do
-    let s' = TE.encodeUtf8 s
-    putE (fromIntegral (B.length s') :: Word16)
-    putByteString s'
+putEventSpec (Message (TE.encodeUtf8 -> s)) = do
+    putE (fromIntegral (B.length s) :: Word16)
+    putByteString s
 
-putEventSpec (UserMessage s) = do
-    let s' = TE.encodeUtf8 s
-    putE (fromIntegral (B.length s') :: Word16)
-    putByteString s'
+putEventSpec (UserMessage (TE.encodeUtf8 -> s)) = do
+    putE (fromIntegral (B.length s) :: Word16)
+    putByteString s
 
-putEventSpec (UserMarker s) = do
-    let s' = TE.encodeUtf8 s
-    putE (fromIntegral (B.length s') :: Word16)
-    putByteString s'
+putEventSpec (UserMarker (TE.encodeUtf8 -> s)) = do
+    putE (fromIntegral (B.length s) :: Word16)
+    putByteString s
 
 putEventSpec (UnknownEvent {}) = error "putEventSpec UnknownEvent"
 
@@ -1395,11 +1388,10 @@ putEventSpec (MerReleaseThread thread_id) =
 putEventSpec MerCapSleeping = return ()
 putEventSpec MerCallingMain = return ()
 
-putEventSpec PerfName{..} = do
-    let name' = TE.encodeUtf8 name
-    putE (fromIntegral (B.length name') + sz_perf_num :: Word16)
+putEventSpec PerfName{name = (TE.encodeUtf8 -> name), ..} = do
+    putE (fromIntegral (B.length name) + sz_perf_num :: Word16)
     putE perfNum
-    putByteString name'
+    putByteString name
 
 putEventSpec PerfCounter{..} = do
     putE perfNum

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -3,7 +3,7 @@ import System.Exit
 
 import GHC.RTS.Events
 import GHC.RTS.Events.Incremental
-import Utils (files, diffLines)
+import Utils (files)
 
 -- | Check that an eventlog round-trips through encoding/decoding.
 checkRoundtrip :: FilePath -> IO Bool
@@ -11,7 +11,6 @@ checkRoundtrip logFile = do
   putStrLn logFile
   Right eventlog <- readEventLogFromFile logFile
   let Right (roundtripped, _) = readEventLog $ serialiseEventLog eventlog
-  let getEvents = sortEvents . events . dat
   if show roundtripped == show eventlog
     then return True
     else putStrLn "bad" >> return False

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -1,0 +1,22 @@
+import Control.Monad
+import System.Exit
+
+import GHC.RTS.Events
+import GHC.RTS.Events.Incremental
+import Utils (files, diffLines)
+
+-- | Check that an eventlog round-trips through encoding/decoding.
+checkRoundtrip :: FilePath -> IO Bool
+checkRoundtrip logFile = do
+  putStrLn logFile
+  Right eventlog <- readEventLogFromFile logFile
+  let Right (roundtripped, _) = readEventLog $ serialiseEventLog eventlog
+  let getEvents = sortEvents . events . dat
+  if show roundtripped == show eventlog
+    then return True
+    else putStrLn "bad" >> return False
+
+main :: IO ()
+main = do
+  successes <- mapM checkRoundtrip files
+  unless (and successes) exitFailure


### PR DESCRIPTION
Previously we used the Binary instance for Text to serialise the event
name. This is wrong.

We now first encode to UTF-8 and use this in the eventlog encoding.