### PR TITLE
Ensure that `ghc-events show` fails with an error on malformed events

### DIFF
--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -10,6 +10,8 @@ import GHC.RTS.Events.Analysis.SparkThread
 import GHC.RTS.Events.Analysis.Thread
 import GHC.RTS.Events.Analysis.Capability
 
+import qualified Data.ByteString.Lazy as BL
+
 import System.Environment (getArgs)
 import Data.Either (rights)
 import qualified Data.Map as M
@@ -175,10 +177,10 @@ command _ = putStr usage >> die "Unrecognized command"
 
 readLogOrDie :: FilePath -> IO EventLog
 readLogOrDie file = do
-    e <- readEventLogFromFile file
-    case e of
-        Left s    -> die ("Failed to parse " ++ file ++ ": " ++ s)
-        Right evtLog -> return evtLog
+    res <- readEventLogOrFail <$> BL.readFile file
+    case res of
+      Left err -> die $ "Failed to parse " ++ file ++ ": " ++ err
+      Right eventlog -> return eventlog
 
 usage :: String
 usage = unlines $ map pad strings

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -77,7 +77,7 @@ library
 executable ghc-events
   import:           default
   main-is:          GhcEvents.hs
-  build-depends:    ghc-events, base, containers
+  build-depends:    ghc-events, base, containers, bytestring
 
 test-suite test-versions
   import:           default


### PR DESCRIPTION
Previous `ghc-events show` would fail to report malformed events. Here we fix this by splitting up `readEvents` to offer:
```haskell
readEvents' :: Header -> BL.ByteString -> [Either String Event]
```
Which gives the user access to event deserialisation errors.

Fixes #85.