### PR TITLE
Add --version option to ghc-events CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Added `--version` option to CLI interface
+
 ## 0.19.0.1 - 2023-04-13
 
 * Update for GHC 9.6 ([#93](https://github.com/haskell/ghc-events/pull/93))

--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -15,13 +15,18 @@ import qualified Data.ByteString.Lazy as BL
 import System.Environment (getArgs)
 import Data.Either (rights)
 import qualified Data.Map as M
+import Data.Version (showVersion)
+import qualified Paths_ghc_events as P
 import System.IO
 import System.Exit
+
 
 main :: IO ()
 main = getArgs >>= command
 
 command :: [String] -> IO ()
+command ["--version"] = putStrLn $ "ghc-events version: " ++ showVersion P.version
+
 command ["--help"] = putStr usage
 
 command ["inc", file] = printEventsIncremental False file
@@ -188,6 +193,7 @@ usage = unlines $ map pad strings
     align = 4 + (maximum . map (length . fst) $ strings)
     pad (x, y) = zipWith const (x ++ repeat ' ') (replicate align ()) ++ y
     strings = [ ("ghc-events --help:",                     "Display this help.")
+              , ("ghc-events --version",                   "Print the version of ghc-events.")
               , ("ghc-events inc <file>:",                 "Pretty print an event log incrementally")
               , ("ghc-events inc force <file>:",           "Pretty print an event log incrementally. Retry on incomplete input (aka 'tail -f').")
               , ("ghc-events show <file>:",                "Pretty print an event log.")

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -70,6 +70,8 @@ library
   other-modules:    GHC.RTS.EventParserUtils,
                     GHC.RTS.EventTypes
                     GHC.RTS.Events.Binary
+                    Paths_ghc_events
+  autogen-modules:  Paths_ghc_events
   hs-source-dirs:   src
   include-dirs:     include
   other-extensions: FlexibleContexts, CPP
@@ -79,6 +81,8 @@ executable ghc-events
   import:           default
   main-is:          GhcEvents.hs
   build-depends:    ghc-events, base, containers, bytestring
+  other-modules:    Paths_ghc_events
+  autogen-modules:  Paths_ghc_events
 
 test-suite test-versions
   import:           default


### PR DESCRIPTION
Output in the usage help:
```console
david@Davids-MacBook-Air ghc-events % ghc-events
ghc-events --help:                        Display this help.
ghc-events --version                      Print the version of ghc-events.
ghc-events inc <file>:                    Pretty print an event log incrementally
ghc-events inc force <file>:              Pretty print an event log incrementally. Retry on incomplete input (aka 'tail -f').
ghc-events show <file>:                   Pretty print an event log.
ghc-events show threads <file>:           Pretty print an event log, ordered by threads.
ghc-events show caps <file>:              Pretty print an event log, ordered by capabilities.
ghc-events merge <out> <in1> <in2>:       Merge two event logs.
ghc-events sparks-csv <file>:             Print spark information in CSV.
ghc-events validate threads <file>:       Validate thread states.
ghc-events validate threadpool <file>:    Validate thread pool state.
ghc-events validate threadrun <file>:     Validate thread running state.
ghc-events validate tasks <file>:         Validate task states.
ghc-events validate sparks <file>:        Validate spark thread states.
ghc-events simulate threads <file>:       Simulate thread states.
ghc-events simulate threadpool <file>:    Simulate thread pool state.
ghc-events simulate threadrun <file>:     Simulate thread running state.
ghc-events simulate tasks <file>:         Simulate task states.
ghc-events simulate sparks <file>:        Simulate spark thread states.
ghc-events profile threads <file>:        Profile thread states.
ghc-events profile sparks <file>:         Profile spark thread states.
Unrecognized command
```

Invocation of the command:

```console
david@Davids-MacBook-Air ghc-events % ghc-events --version
ghc-events version: 0.19.0.1
```