### PR TITLE
Drop unused cpp which was used for compatibility with GHC < 8.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+* Added `--version` option to CLI interface
+
 ## 0.19.0.1 - 2023-04-13
 
 * Update for GHC 9.6 ([#93](https://github.com/haskell/ghc-events/pull/93))

--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Main where
 
 import GHC.RTS.Events
@@ -248,8 +246,3 @@ showMap showKey showValue m =
   concat $ zipWith (++)
     (map showKey . M.keys $ m :: [String])
     (map (showValue . (M.!) m) . M.keys $ m :: [String])
-
-#if !MIN_VERSION_base(4,8,0)
-die :: String -> IO a
-die err = hPutStrLn stderr err >> exitFailure
-#endif

--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -15,13 +15,18 @@ import qualified Data.ByteString.Lazy as BL
 import System.Environment (getArgs)
 import Data.Either (rights)
 import qualified Data.Map as M
+import Data.Version (showVersion)
+import qualified Paths_ghc_events as P
 import System.IO
 import System.Exit
+
 
 main :: IO ()
 main = getArgs >>= command
 
 command :: [String] -> IO ()
+command ["--version"] = putStrLn $ "ghc-events version: " ++ showVersion P.version
+
 command ["--help"] = putStr usage
 
 command ["inc", file] = printEventsIncremental False file
@@ -188,6 +193,7 @@ usage = unlines $ map pad strings
     align = 4 + (maximum . map (length . fst) $ strings)
     pad (x, y) = zipWith const (x ++ repeat ' ') (replicate align ()) ++ y
     strings = [ ("ghc-events --help:",                     "Display this help.")
+              , ("ghc-events --version",                   "Print the version of ghc-events.")
               , ("ghc-events inc <file>:",                 "Pretty print an event log incrementally")
               , ("ghc-events inc force <file>:",           "Pretty print an event log incrementally. Retry on incomplete input (aka 'tail -f').")
               , ("ghc-events show <file>:",                "Pretty print an event log.")

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -70,6 +70,8 @@ library
   other-modules:    GHC.RTS.EventParserUtils,
                     GHC.RTS.EventTypes
                     GHC.RTS.Events.Binary
+                    Paths_ghc_events
+  autogen-modules:  Paths_ghc_events
   hs-source-dirs:   src
   include-dirs:     include
   other-extensions: FlexibleContexts, CPP
@@ -79,6 +81,8 @@ executable ghc-events
   import:           default
   main-is:          GhcEvents.hs
   build-depends:    ghc-events, base, containers, bytestring
+  other-modules:    Paths_ghc_events
+  autogen-modules:  Paths_ghc_events
 
 test-suite test-versions
   import:           default

--- a/src/GHC/RTS/Events.hs
+++ b/src/GHC/RTS/Events.hs
@@ -95,11 +95,6 @@ import GHC.RTS.EventTypes
 import GHC.RTS.Events.Binary
 import GHC.RTS.Events.Incremental
 
-#if !MIN_VERSION_base(4, 8, 0)
-import Data.Foldable (foldMap)
-import Data.Monoid (mempty)
-#endif
-
 #if !MIN_VERSION_base(4, 11, 0)
 import Data.Monoid ((<>))
 #endif

--- a/src/GHC/RTS/Events/Incremental.hs
+++ b/src/GHC/RTS/Events/Incremental.hs
@@ -131,10 +131,6 @@ readEvents :: Header -> BL.ByteString -> ([Event], Maybe String)
 readEvents header = f . break isLeft . readEvents' header
   where
     f (rs, ls) = (rights rs, listToMaybe (lefts ls))
-#if !MIN_VERSION_base(4, 7, 0)
-    isLeft (Left _) = True
-    isLeft _ = False
-#endif
 
 -- | Read events from a lazy bytestring. It returns an error message if it
 -- encounters an error while decoding the header.


### PR DESCRIPTION
Compatibility with GHC < 8.* was dropped in #89 , so this PR removes some CPP which was used to guarantee compatibility with base versions which correspond to earlier GHC versions. See the table in: https://www.snoyman.com/base/