### PR TITLE
Remove CPP which was used for compatibility with GHC < 8.*

### DIFF
--- a/GhcEvents.hs
+++ b/GhcEvents.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Main where
 
 import GHC.RTS.Events
@@ -242,8 +240,3 @@ showMap showKey showValue m =
   concat $ zipWith (++)
     (map showKey . M.keys $ m :: [String])
     (map (showValue . (M.!) m) . M.keys $ m :: [String])
-
-#if !MIN_VERSION_base(4,8,0)
-die :: String -> IO a
-die err = hPutStrLn stderr err >> exitFailure
-#endif

--- a/src/GHC/RTS/Events.hs
+++ b/src/GHC/RTS/Events.hs
@@ -95,11 +95,6 @@ import GHC.RTS.EventTypes
 import GHC.RTS.Events.Binary
 import GHC.RTS.Events.Incremental
 
-#if !MIN_VERSION_base(4, 8, 0)
-import Data.Foldable (foldMap)
-import Data.Monoid (mempty)
-#endif
-
 #if !MIN_VERSION_base(4, 11, 0)
 import Data.Monoid ((<>))
 #endif

--- a/src/GHC/RTS/Events/Incremental.hs
+++ b/src/GHC/RTS/Events/Incremental.hs
@@ -131,10 +131,6 @@ readEvents :: Header -> BL.ByteString -> ([Event], Maybe String)
 readEvents header = f . break isLeft . readEvents' header
   where
     f (rs, ls) = (rights rs, listToMaybe (lefts ls))
-#if !MIN_VERSION_base(4, 7, 0)
-    isLeft (Left _) = True
-    isLeft _ = False
-#endif
 
 -- | Read events from a lazy bytestring. It returns an error message if it
 -- encounters an error while decoding the header.


### PR DESCRIPTION
Compatibility with GHC < 8.* was dropped in https://github.com/haskell/ghc-events/pull/89 , so this PR removes some CPP which was used to guarantee compatibility with base versions which correspond to earlier GHC versions. See the table in: https://www.snoyman.com/base/