### PR TITLE
Fix type of ProfSampleCostCentre.profCapSet event field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added `--version` option to CLI interface
+* Fix the type of the `profCap` field of `ProfSampleCostCentre`
 
 ## 0.19.0.1 - 2023-04-13
 

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -1,6 +1,6 @@
 cabal-version:    2.4
 name:             ghc-events
-version:          0.19.0.1
+version:          0.20.0.0
 synopsis:         Library and tool for parsing .eventlog files from GHC
 description:      Parses .eventlog files emitted by GHC 8.0.2 and later.
                   Includes the ghc-events tool permitting, in particular,

--- a/src/GHC/RTS/EventTypes.hs
+++ b/src/GHC/RTS/EventTypes.hs
@@ -435,7 +435,7 @@ data EventInfo
                        }
 
   | ProfSampleCostCentre
-                       { profCapset :: !Capset
+                       { profCap :: !CapNo
                        , profTicks :: !Word64
                        , profStackDepth :: !Word8
                        , profCcsStack :: !(VU.Vector Word32)

--- a/src/GHC/RTS/Events.hs
+++ b/src/GHC/RTS/Events.hs
@@ -489,7 +489,7 @@ buildEventInfo spec' =
           <> ", label " <> TB.fromText heapProfLabel
 
         ProfSampleCostCentre {..} ->
-          "cap no " <> TB.decimal profCapset
+          "cap no " <> TB.decimal profCap
           <> ", prof sample " <> TB.decimal profTicks
           <> ", cost centre stack " <> buildCostCentreStack profCcsStack
 

--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeApplications #-}
 module GHC.RTS.Events.Binary
   ( -- * Readers
     getHeader
@@ -751,7 +752,7 @@ timeProfParsers = [
     return $! ProfBegin{..}
   , VariableSizeParser EVENT_PROF_SAMPLE_COST_CENTRE $ do
     payloadLen <- get :: Get Word16
-    profCapset <- get
+    profCap <- fromIntegral @Int32 @CapNo <$> get
     profTicks <- get
     profStackDepth <- get
     profCcsStack <- VU.replicateM (fromIntegral profStackDepth) get
@@ -1420,7 +1421,7 @@ putEventSpec HeapProfSampleString {..} = do
     putE $ T.unpack heapProfLabel
 
 putEventSpec ProfSampleCostCentre {..} = do
-    putE profCapset
+    putE $ fromIntegral @CapNo @Int16 profCap
     putE profTicks
     putE profStackDepth
     VU.mapM_ putE profCcsStack


### PR DESCRIPTION
This is a CapNo rather than a CapSet.
The event stores this as an Int32, but CapNo is an Int16. So we need to do some conversions.

Resolves #84

NB: this is a breaking change, as we change the type and name of this field