### PR TITLE
Drop dependency on array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Drop dependency on `array` ([#114](https://github.com/haskell/ghc-events/pull/114))
 
 
 ## 0.20.0.0 - 2024-11-25

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -60,7 +60,6 @@ library
                     containers >= 0.5 && < 0.8,
                     binary     >= 0.7 && < 0.11,
                     bytestring >= 0.10.4 && < 0.13,
-                    array      >= 0.2 && < 0.6,
                     text       >= 0.11.2.3 && < 2.2,
                     vector     >= 0.7 && < 0.14
   exposed-modules:  GHC.RTS.Events,

--- a/src/GHC/RTS/EventParserUtils.hs
+++ b/src/GHC/RTS/EventParserUtils.hs
@@ -12,26 +12,27 @@ module GHC.RTS.EventParserUtils (
         skip,
     ) where
 
-import Data.Array
 import Data.Binary
 import Data.Binary.Get ()
 import Data.Binary.Put ()
 import Data.IntMap (IntMap)
 import Data.List
 import Data.Text (Text)
+import Data.Vector (Vector)
 import qualified Data.Binary.Get as G
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.IntMap as M
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
+import qualified Data.Vector as Vec
 
 #define EVENTLOG_CONSTANTS_ONLY
 #include "EventLogFormat.h"
 
 import GHC.RTS.EventTypes
 
-newtype EventParsers = EventParsers (Array Int (Get EventInfo))
+newtype EventParsers = EventParsers (Vector (Get EventInfo))
 
 getString :: Integral a => a -> Get String
 getString len = do
@@ -123,10 +124,10 @@ simpleEvent t p = FixedSizeParser t 0 (return p)
 
 mkEventTypeParsers :: IntMap EventType
                    -> [EventParser EventInfo]
-                   -> Array Int (Get EventInfo)
+                   -> Vector (Get EventInfo)
 mkEventTypeParsers etypes event_parsers
- = accumArray (flip const) undefined (0, max_event_num)
-    [ (num, parser num) | num <- [0..max_event_num] ]
+ = Vec.fromList
+    [ parser num | num <- [0..max_event_num] ]
   where
     max_event_num = maximum (M.keys etypes)
     undeclared_etype num = fail ("undeclared event type: " ++ show num)

--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -33,7 +33,7 @@ import Data.Maybe
 import Data.Int
 import Prelude hiding (gcd, rem, id)
 
-import Data.Array
+import Data.Vector ((!))
 import Data.Binary
 import Data.Binary.Put
 import qualified Data.Binary.Get as G


### PR DESCRIPTION
We already depend on vector, so let's just use that for all of our array needs