### PR TITLE
Make definition of Monoid MaxVars cannonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Drop dependency on `array` ([#114](https://github.com/haskell/ghc-events/pull/114))
+* Make definition of `Monoid MaxVars` cannonical ([#115](https://github.com/haskell/ghc-events/pull/115))
 
 
 ## 0.20.0.0 - 2024-11-25

--- a/src/GHC/RTS/Events/Merge.hs
+++ b/src/GHC/RTS/Events/Merge.hs
@@ -49,15 +49,22 @@ data MaxVars = MaxVars { mcapset :: !Word32
                        , mthread :: !ThreadId }
 -- TODO introduce parallel RTS process and machine var.s
 
+combineMaxVars :: MaxVars -> MaxVars -> MaxVars
+combineMaxVars (MaxVars a b c) (MaxVars x y z) =
+      MaxVars (max a x) (b + y) (max c z)
+
 #if MIN_VERSION_base(4,11,0)
 instance Semigroup MaxVars where
-    (<>) = mappend
+    (<>) = combineMaxVars
 #endif
 
 instance Monoid MaxVars where
     mempty  = MaxVars 0 0 0
-    mappend (MaxVars a b c) (MaxVars x y z) =
-      MaxVars (max a x) (b + y) (max c z)
+#if MIN_VERSION_base(4,11,0)
+    mappend = (<>)
+#else
+    mappend = combineMaxVars
+#endif
     -- avoid space leaks:
     mconcat = foldl' mappend mempty
 


### PR DESCRIPTION
Unfortunately we can't drop this CPP yet, so this is a bit messy and requires putting the definition into another function.