### PR TITLE
Export step from GHC.RTS.Events.Analysis

### DIFF
--- a/src/GHC/RTS/Events/Analysis.hs
+++ b/src/GHC/RTS/Events/Analysis.hs
@@ -1,5 +1,6 @@
 module GHC.RTS.Events.Analysis
   ( Machine (..)
+  , step
   , validate
   , validates
   , simulate


### PR DESCRIPTION
Exporting the `step` function allows users to run this machine incrementally. This is not possible with the currently  exported API, except by simply locally re-implementing the `step` function.