### PR TITLE
Better error message when event log is corrupted

### DIFF
--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -33,7 +33,7 @@ import Data.Maybe
 import Data.Int
 import Prelude hiding (gcd, rem, id)
 
-import Data.Vector ((!))
+import Data.Vector ((!?))
 import Data.Binary
 import Data.Binary.Put
 import qualified Data.Binary.Get as G
@@ -100,7 +100,8 @@ getEvent (EventParsers parsers) = do
   if etRef == EVENT_DATA_END
      then return Nothing
      else do !evTime   <- get
-             evSpec <- parsers ! fromIntegral etRef
+             evSpec <- fromMaybe (fail $ "Unrecognized event type: " ++ show etRef) $
+               parsers !? fromIntegral etRef
              return $ Just Event { evCap = undefined, .. }
 
 --


### PR DESCRIPTION
When we read a corrupted event log, we will often encounter unknown event types. Previously we failed with an index out of bounds error. This is really unhelpful for our users. We should give them a proper error message.