### PR TITLE
Allow roundtripping NonmovingHeapCensus event

### DIFF
--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -70,9 +70,9 @@ library
                     GHC.RTS.Events.Analysis.Capability
                     GHC.RTS.Events.Analysis.SparkThread
                     GHC.RTS.Events.Analysis.Thread
+                    GHC.RTS.Events.Binary
   other-modules:    GHC.RTS.EventParserUtils,
                     GHC.RTS.EventTypes
-                    GHC.RTS.Events.Binary
                     Paths_ghc_events
   autogen-modules:  Paths_ghc_events
   hs-source-dirs:   src

--- a/ghc-events.cabal
+++ b/ghc-events.cabal
@@ -87,6 +87,13 @@ executable ghc-events
   other-modules:    Paths_ghc_events
   autogen-modules:  Paths_ghc_events
 
+test-suite unit-tests
+  import:           default
+  type:             exitcode-stdio-1.0
+  main-is:          Unit.hs
+  hs-source-dirs:   test
+  build-depends:    ghc-events, base, binary, hspec, bytestring
+
 test-suite test-versions
   import:           default
   type:             exitcode-stdio-1.0

--- a/src/GHC/RTS/EventTypes.hs
+++ b/src/GHC/RTS/EventTypes.hs
@@ -457,10 +457,13 @@ data EventInfo
   | ConcUpdRemSetFlush { cap    :: {-# UNPACK #-}!Int
                        }
   | NonmovingHeapCensus
-                       { nonmovingCensusBlkSize :: !Word16
+                       { -- | Block size
+                         nonmovingCensusBlkSize :: !Word16
                        , nonmovingCensusActiveSegs :: !Word32
                        , nonmovingCensusFilledSegs :: !Word32
                        , nonmovingCensusLiveBlocks :: !Word32
+                       -- See: Note [Encoding of NonmovingHeapCensus]
+                       , encodedAsLog :: !Bool
                        }
   | NonmovingPrunedSegments
                        { -- | The number of pruned segments.
@@ -486,6 +489,13 @@ data EventInfo
                        }
   | TickyBeginSample
   deriving Show
+
+-- Note [Encoding of NonmovingHeapCensus]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- Before GHC-9.10, block size was encoded as the base-2 logarithm.
+-- Since GHC-9.10, it is now just written directly as the block size and is not necessarily a power of 2.
+-- We need to record this information in order to roundtrips events, but otherwise it shouldn't matter to users.
 
 --sync with ghc/includes/Constants.h
 data ThreadStopStatus

--- a/src/GHC/RTS/EventTypes.hs
+++ b/src/GHC/RTS/EventTypes.hs
@@ -129,7 +129,7 @@ data Event =
     evTime  :: {-# UNPACK #-}!Timestamp,
     evSpec  :: EventInfo,
     evCap :: Maybe Int
-  } deriving Show
+  } deriving (Eq, Show)
 
 {-# DEPRECATED time "The field is now called evTime" #-}
 time :: Event -> Timestamp
@@ -488,7 +488,7 @@ data EventInfo
                        , tickyCtrSampleAllocd     :: !Word64
                        }
   | TickyBeginSample
-  deriving Show
+  deriving (Eq, Show)
 
 -- Note [Encoding of NonmovingHeapCensus]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -520,7 +520,7 @@ data ThreadStopStatus
  | ThreadMigrating
  | BlockedOnMsgGlobalise
  | BlockedOnBlackHoleOwnedBy {-# UNPACK #-}!ThreadId
- deriving (Show)
+ deriving (Eq, Show)
 
 mkStopStatus :: RawThreadStopStatus -> Word32 -> ThreadStopStatus
 mkStopStatus n i = case n of
@@ -555,7 +555,7 @@ data CapsetType
  | CapsetOsProcess
  | CapsetClockDomain
  | CapsetUnknown
- deriving Show
+ deriving (Eq, Show)
 
 mkCapsetType :: Word16 -> CapsetType
 mkCapsetType n = case n of
@@ -583,7 +583,7 @@ data MessageTag
   -- with GUM and its variants, add:
   -- ...| Fetch | Resume | Ack
   -- ...| Fish | Schedule | Free | Reval | Shark
-  deriving (Enum, Show)
+  deriving (Eq, Enum, Show)
 offset :: RawMsgTag
 offset = 0x50
 
@@ -605,7 +605,7 @@ data HeapProfBreakdown
   | HeapProfBreakdownClosureType
   | HeapProfBreakdownInfoTable
   | HeapProfBreakdownEra
-  deriving Show
+  deriving (Eq, Show)
 
 instance Binary HeapProfBreakdown where
   get = do
@@ -635,7 +635,7 @@ instance Binary HeapProfBreakdown where
 
 
 newtype HeapProfFlags = HeapProfFlags Word8
-  deriving (Show, Binary)
+  deriving (Eq, Show, Binary)
 
 isCaf :: HeapProfFlags -> Bool
 isCaf (HeapProfFlags w8) = testBit w8 0

--- a/src/GHC/RTS/Events/Binary.hs
+++ b/src/GHC/RTS/Events/Binary.hs
@@ -29,6 +29,7 @@ module GHC.RTS.Events.Binary
 import Control.Exception (assert)
 import Control.Monad
 import Data.List (intersperse)
+import Data.Bits (countLeadingZeros)
 import Data.Maybe
 import Data.Int
 import Prelude hiding (gcd, rem, id)
@@ -352,6 +353,7 @@ standardParsers = [
       nonmovingCensusActiveSegs <- get :: Get Word32
       nonmovingCensusFilledSegs <- get :: Get Word32
       nonmovingCensusLiveBlocks <- get :: Get Word32
+      let encodedAsLog = True
       return NonmovingHeapCensus{..}
     )),
  (FixedSizeParser EVENT_NONMOVING_HEAP_CENSUS 14 (do -- (blk_size, active_segs, filled_segs, live_blks)
@@ -359,6 +361,7 @@ standardParsers = [
       nonmovingCensusActiveSegs <- get :: Get Word32
       nonmovingCensusFilledSegs <- get :: Get Word32
       nonmovingCensusLiveBlocks <- get :: Get Word32
+      let encodedAsLog = False
       return NonmovingHeapCensus{..}
     )),
  (FixedSizeParser EVENT_NONMOVING_PRUNED_SEGMENTS 8 (do -- (pruned_segments, free_segments)
@@ -1444,7 +1447,16 @@ putEventSpec ConcSweepBegin = return ()
 putEventSpec ConcSweepEnd = return ()
 putEventSpec ConcUpdRemSetFlush {..} = do
     putCap cap
-putEventSpec NonmovingHeapCensus {..} = do
+putEventSpec NonmovingHeapCensus {encodedAsLog = True, ..} = do
+    -- See: Note [Encoding of NonmovingHeapCensus]
+    let
+      log2 :: Word16 -> Word8
+      log2 x = 15 - fromIntegral @Int @Word8 (countLeadingZeros x)
+    putE $ log2 nonmovingCensusBlkSize
+    putE nonmovingCensusActiveSegs
+    putE nonmovingCensusFilledSegs
+    putE nonmovingCensusLiveBlocks
+putEventSpec NonmovingHeapCensus {encodedAsLog = False, ..} = do
     putE nonmovingCensusBlkSize
     putE nonmovingCensusActiveSegs
     putE nonmovingCensusFilledSegs

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Test.Hspec
+import GHC.RTS.Events (EventInfo(..), Event(..), Header(..), Data(..), serialiseEventLog, EventLog(..), EventType(..))
+import Data.Binary.Put (runPut)
+import Data.ByteString (ByteString)
+import GHC.RTS.Events.Incremental (readEvents, readHeader, readEventLog)
+import qualified Data.ByteString.Lazy as BL
+import GHC.RTS.Events.Binary (putEvent)
+
+main :: IO ()
+main = hspec $ do
+  describe "NonMovingHeapCensus" $ do
+    it "can roundtrip logarithmic version" $ do
+      roundtrips [EventType {num = 207, desc = "Nonmoving heap census", size = Just 13}] NonmovingHeapCensus
+        { nonmovingCensusBlkSize = 8
+        , nonmovingCensusActiveSegs = 1
+        , nonmovingCensusFilledSegs = 2
+        , nonmovingCensusLiveBlocks = 3
+        , encodedAsLog = True
+        }
+    it "can roundtrip non-logarithmic version" $ do
+      roundtrips [EventType {num = 207, desc = "Nonmoving heap census", size = Just 14}] NonmovingHeapCensus
+        { nonmovingCensusBlkSize = 8
+        , nonmovingCensusActiveSegs = 1
+        , nonmovingCensusFilledSegs = 2
+        , nonmovingCensusLiveBlocks = 3
+        , encodedAsLog = False
+        }
+
+roundtrips :: [EventType] -> EventInfo -> IO ()
+roundtrips header evInfo = do
+  let event = Event 0 evInfo Nothing
+  let enc = runPut $ putEvent event
+  ([dec], _) <- pure $ readEvents (Header header) enc
+  event `shouldBe` dec


### PR DESCRIPTION
This event has two versions. Previously we always output the new version.
We now add a flag to the event to indicate which version it is.

Resolves https://github.com/haskell/ghc-events/issues/127